### PR TITLE
Code restructuring and addition of 'Test Current File' option

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -4,10 +4,17 @@
         "command": "simple_php_unit"
     },
     {
-        "caption": "PHPUnit: Run with params",
+        "caption": "PHPUnit: Test current file",
         "command": "simple_php_unit",
         "args": {
-            "params": true
+            "test_current_file": true
+        }
+    },
+    {
+        "caption": "PHPUnit: Run with custom args",
+        "command": "simple_php_unit",
+        "args": {
+            "custom_args": true
         }
     }
 ]

--- a/README.md
+++ b/README.md
@@ -1,36 +1,55 @@
-Simple PHPUnit commands
+SimplePHPUnit
 ===============
 
-This plugin allows you the run the PHPUnit tests using the Sublime Text interface, without having to open and use the command line.
+This plugin allows you the run PHPUnit tests straight from the Sublime Text interface.
 
-### Available commands:
+### Available commands
+**`Run`**
+This is the equivalent of running: `phpunit` _`<sublime project root directory>`_
 
-- `PHPUnit: Run`
-- `PHPUnit: Run with params`
+**`Test current file`**
+This is the equivalent of running: `phpunit` _`<path to current file>`_
 
-### Coloring output:
+**`Run with custom args`**
+Opens a new input window which allows user to enter PHPUnit arguments to be added to the command.  This is the equivalent of running: `phpunit` _`<user-entered arguments>`_
 
+***Please see the settings file after installation to see options that could affect the behavior of these commands***
+
+### Colored output:
 ![Coloring output](https://raw.github.com/m0nah/SimplePHPUnit-for-Sublime-Text/master/Screen%20Shot.png)
 
 ### Installation:
-Use Package Controller or create a the directory `SimplePHPUnit` in your Sublime Text Packages directory, and you're ready to go.
+1. Use [Package Control](https://packagecontrol.io/installation) to install `SimplePHPUnit`
+2. Download and unzip the plugin files to `<Your ST2-ST3 Packages Directory>\SimplePHPUnit\`
 
 ### Usage:
-Press Cmd + Shift + P for the dropdown command list, search for `PHPUnit: `, and pick your command. Also you can use `Tools/PHPUnit...` menu item
+1. Press Cmd + Shift + P to open the control palette
+2. Search for `PHPUnit: ` and pick your command
+
+Also you can use the `Tools --> PHPUnit...` menu item, or set up custom keybindings
 
 ### Keybinding:
-
 You can use command `simple_php_unit` for your keybinding.
 
-Example:
-
+**Examples**:
 ```json
-{ "keys": ["super+ctrl+alt+t"], "command": "simple_php_unit" }
+{
+	"keys": ["ctrl+alt+t"],
+	"command": "simple_php_unit"
+},
+{
+	"keys": ["super+ctrl+alt+t"],
+	"command": "simple_php_unit",
+	"args": {
+        "test_current_file": true
+    }
+}
 ```
 
 ### Notes:
-- PHPUnit config file needs to been in the root folder of your structure in the sidebar.
-- You need insert in Sublime Text user settings `"show_panel_on_build": true` or use `Tools/Build Results/Show Build Results` menu item for view results.
+- Latest version of the plugin built and tested using [PHPUnit 4.4](https://phpunit.de/).
+- If your projects use XML configuration files for PHPUnit, be sure to specify them in your user settings.
+- Enable automatic output panel display by adding `"show_panel_on_build": true` to your user settings or use the `Tools --> Build Results --> Show Build Results` menu item to view results.
 
 ### Donate:
 If you liked this plugin, you can donate to support it!

--- a/SimplePHPUnit.py
+++ b/SimplePHPUnit.py
@@ -1,4 +1,5 @@
 import os
+import re
 import sys
 import shlex
 import subprocess
@@ -11,6 +12,14 @@ if sys.version_info < (3, 3):
 SPU_THEME = 'Packages/SimplePHPUnit/SimplePHPUnit.hidden-tmTheme'
 SPU_SYNTAX = 'Packages/SimplePHPUnit/SimplePHPUnit.hidden-tmLanguage'
 
+
+class NoOpenProjectException(Exception):
+    pass
+
+class InvalidFileTypeException(Exception):
+    pass
+
+
 class ShowInPanel:
     def __init__(self, window):
         self.window = window
@@ -22,40 +31,64 @@ class ShowInPanel:
         self.panel.settings().set("color_scheme", SPU_THEME)
         self.panel.set_syntax_file(SPU_SYNTAX)
 
+
 class SimplePhpUnitCommand(sublime_plugin.WindowCommand):
     def __init__(self, *args, **kwargs):
         super(SimplePhpUnitCommand, self).__init__(*args, **kwargs)
         settings = sublime.load_settings('SimplePHPUnit.sublime-settings')
-        self.phpunit_path = settings.get('phpunit_path')
+        self.phpunit_executable = settings.get('phpunit_executable')
+        self.xml_config_file = settings.get('phpunit_xml_config_file')
 
     def run(self, *args, **kwargs):
         try:
-            # The first folder needs to be the Laravel Project
+            self.build_and_run_phpunit_command(args, kwargs)
+        except (IOError, NoOpenProjectException, InvalidFileTypeException) as e:
+            sublime.status_message(str(e))
+            
+
+    def build_and_run_phpunit_command(self, args, kwargs):
+            self.ensure_open_project()
+            self.reset_command_args()
+            self.file_to_test = None
+
+            if kwargs.get('custom_args') is True:
+                self.window.show_input_panel('PHPUnit Arguments:', '', self.set_custom_arguments_and_run_phpunit, None, None)
+                return
+
+            if kwargs.get('test_current_file'):
+                current_filename = self.window.active_view().file_name()
+                if current_filename.endswith('.php') is False:
+                    raise InvalidFileTypeException('PHPUnit can only be run on PHP files')
+                self.file_to_test = current_filename
+                
+            self.run_phpunit()
+
+    def reset_command_args(self):
+        self.args = [self.phpunit_executable, '--stderr']
+        if self.xml_config_file and os.path.isfile(self.xml_config_file):
+            self.args += ['--config', self.xml_config_file]
+
+    def ensure_open_project(self):
+        try:
             self.PROJECT_PATH = self.window.folders()[0]
-            if os.path.isfile("%s" % os.path.join(self.PROJECT_PATH, 'phpunit.xml')) or os.path.isfile("%s" % os.path.join(self.PROJECT_PATH, 'phpunit.xml.dist')):
-                self.params = kwargs.get('params', False)
-                self.args = [self.phpunit_path, '--stderr']
-                if self.params is True:
-                    self.window.show_input_panel('Params:', '', self.on_params, None, None)
-                else:
-                    self.on_done()
-            else:
-                sublime.status_message("phpunit.xml or phpunit.xml.dist not found")
         except IndexError:
-            sublime.status_message("Please open a project with PHPUnit")
+            raise NoOpenProjectException("PHPUnit must be run from an open Sublime project")
 
-    def on_params(self, command):
-        self.command = command
-        self.args.extend(shlex.split(str(self.command)))
-        self.on_done()
+    def set_custom_arguments_and_run_phpunit(self, command):
+        self.args.extend(shlex.split(str(command)))
+        self.run_phpunit()
 
-    def on_done(self):
+    def run_phpunit(self):
+        if self.file_to_test:
+            self.args.append(self.file_to_test)
+
         if os.name != 'posix':
             self.args = subprocess.list2cmdline(self.args)
+
         try:
             self.run_shell_command(self.args, self.PROJECT_PATH)
         except IOError:
-            sublime.status_message('IOError - command aborted')
+            raise IOError('IOError - PHPUnit command aborted')
 
     def run_shell_command(self, command, working_dir):
             self.window.run_command("exec", {
@@ -64,7 +97,6 @@ class SimplePhpUnitCommand(sublime_plugin.WindowCommand):
                 "working_dir": working_dir
             })
             self.display_results()
-            return True
 
     def display_results(self):
         display = ShowInPanel(self.window)

--- a/SimplePHPUnit.py
+++ b/SimplePHPUnit.py
@@ -19,6 +19,9 @@ class NoOpenProjectException(Exception):
 class InvalidFileTypeException(Exception):
     pass
 
+class NoActiveFileException(Exception):
+    pass
+
 
 class ShowInPanel:
     def __init__(self, window):
@@ -42,7 +45,7 @@ class SimplePhpUnitCommand(sublime_plugin.WindowCommand):
     def run(self, *args, **kwargs):
         try:
             self.build_and_run_phpunit_command(args, kwargs)
-        except (IOError, NoOpenProjectException, InvalidFileTypeException) as e:
+        except (IOError, NoOpenProjectException, InvalidFileTypeException, NoActiveFileException) as e:
             sublime.status_message(str(e))
             
 
@@ -57,6 +60,8 @@ class SimplePhpUnitCommand(sublime_plugin.WindowCommand):
 
             if kwargs.get('test_current_file'):
                 current_filename = self.window.active_view().file_name()
+                if current_filename is None:
+                    raise NoActiveFileException('A file must be open in the editor to run PHPUnit on the current file')
                 if current_filename.endswith('.php') is False:
                     raise InvalidFileTypeException('PHPUnit can only be run on PHP files')
                 self.file_to_test = current_filename

--- a/SimplePHPUnit.sublime-settings
+++ b/SimplePHPUnit.sublime-settings
@@ -1,3 +1,7 @@
 {
-	"phpunit_path": "phpunit"
+    // Path to the PHPUnit executable
+	"phpunit_executable": "phpunit",
+
+    // Full path to PHPUnit XLM configuration file
+    "phpunit_xml_config_file": ""
 }


### PR DESCRIPTION
First pull request I've submitted for an open-source project on GitHub...love the SimplePHPUnit plugin!  I wanted to add an option to quickly test the current unit test class I was working on, as well as add an option to specify the XML config to use.  Fairly new to Python so please give constructive criticism if required.  Thanks!

pr0ggy

**Changes**
- Commands file updated with new 'Test Current File' command
- Settings file updated with option to specify path to XML config file
- Allowed PHPUnit to run even if XML config isn't set as it may not need to be in all cases
- General code refactoring, pulling out methods, etc.
